### PR TITLE
Search for all information fields

### DIFF
--- a/src/main/java/seedu/connectus/commons/util/StringUtil.java
+++ b/src/main/java/seedu/connectus/commons/util/StringUtil.java
@@ -39,6 +39,32 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains the {@code word}.
+     *   Ignores case, but a full word match is required.
+     *   <br>examples:<pre>
+     *       containsWordIgnoreCase("ABc def", "abc") == true
+     *       containsWordIgnoreCase("ABc def", "DEF") == true
+     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       </pre>
+     * @param sentence cannot be null
+     * @param word cannot be null, cannot be empty, must be a single word
+     */
+    public static boolean containsKeywordsListIgnoreCase(String sentence, String word) {
+        requireNonNull(sentence);
+        requireNonNull(word);
+
+        String preppedWord = word.trim();
+        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
+        checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
+
+        String preppedSentence = sentence.toLowerCase();
+        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
+
+        return Arrays.stream(wordsInPreppedSentence)
+                .anyMatch(singleWord -> singleWord.contains(preppedWord.toLowerCase()));
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/connectus/commons/util/StringUtil.java
+++ b/src/main/java/seedu/connectus/commons/util/StringUtil.java
@@ -42,9 +42,9 @@ public class StringUtil {
      * Returns true if the {@code sentence} contains the {@code word}.
      *   Ignores case, but a full word match is required.
      *   <br>examples:<pre>
-     *       containsWordIgnoreCase("ABc def", "abc") == true
-     *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       containsKeywordsListIgnoreCase("ABc def", "abc") == true
+     *       containsKeywordsListIgnoreCase("ABc def", "DEF") == true
+     *       containsKeywordsListIgnoreCase("ABc def", "AB") == false //not a full word match
      *       </pre>
      * @param sentence cannot be null
      * @param word cannot be null, cannot be empty, must be a single word

--- a/src/main/java/seedu/connectus/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/connectus/logic/commands/SearchCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.connectus.commons.core.Messages;
 import seedu.connectus.model.Model;
 import seedu.connectus.model.person.NameContainsKeywordsPredicate;
+import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
 
 /**
  * Finds and lists all persons in ConnectUS whose name contains any of the argument keywords.
@@ -19,9 +20,10 @@ public class SearchCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    // private final NameContainsKeywordsPredicate predicate;
+    private final FieldsContainKeywordsPredicate predicate;
 
-    public SearchCommand(NameContainsKeywordsPredicate predicate) {
+    public SearchCommand(FieldsContainKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/connectus/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/connectus/logic/commands/SearchCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.connectus.commons.core.Messages;
 import seedu.connectus.model.Model;
-import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
 
 /**
@@ -20,7 +19,6 @@ public class SearchCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    // private final NameContainsKeywordsPredicate predicate;
     private final FieldsContainKeywordsPredicate predicate;
 
     public SearchCommand(FieldsContainKeywordsPredicate predicate) {

--- a/src/main/java/seedu/connectus/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/connectus/logic/commands/SearchCommand.java
@@ -7,17 +7,17 @@ import seedu.connectus.model.Model;
 import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
 
 /**
- * Finds and lists all persons in ConnectUS whose name contains any of the argument keywords.
+ * Finds and lists all persons in ConnectUS whose fields contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class SearchCommand extends Command {
 
     public static final String COMMAND_WORD = "search";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose fields contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " alex may CS2103T";
 
     private final FieldsContainKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/connectus/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/connectus/logic/parser/SearchCommandParser.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import seedu.connectus.logic.commands.SearchCommand;
 import seedu.connectus.logic.parser.exceptions.ParseException;
+import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
 import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -25,9 +26,9 @@ public class SearchCommandParser implements Parser<SearchCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        String[] fieldKeywords = trimmedArgs.split("\\s+");
 
-        return new SearchCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new SearchCommand(new FieldsContainKeywordsPredicate(Arrays.asList(fieldKeywords)));
     }
 
 }

--- a/src/main/java/seedu/connectus/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/connectus/logic/parser/SearchCommandParser.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import seedu.connectus.logic.commands.SearchCommand;
 import seedu.connectus.logic.parser.exceptions.ParseException;
 import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
-import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object

--- a/src/main/java/seedu/connectus/model/person/FieldsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/connectus/model/person/FieldsContainKeywordsPredicate.java
@@ -1,0 +1,29 @@
+package seedu.connectus.model.person;
+
+import seedu.connectus.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s information fields matches any of the keywords given.
+ */
+public class FieldsContainKeywordsPredicate implements Predicate<Person>{
+    private final List<String> keywords;
+
+    public FieldsContainKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream().anyMatch(keyword -> StringUtil.containsKeywordsListIgnoreCase(person.getAllFieldsAsString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FieldsContainKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((FieldsContainKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/connectus/model/person/FieldsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/connectus/model/person/FieldsContainKeywordsPredicate.java
@@ -1,14 +1,14 @@
 package seedu.connectus.model.person;
 
-import seedu.connectus.commons.util.StringUtil;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.connectus.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Person}'s information fields matches any of the keywords given.
  */
-public class FieldsContainKeywordsPredicate implements Predicate<Person>{
+public class FieldsContainKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
     public FieldsContainKeywordsPredicate(List<String> keywords) {
@@ -17,7 +17,8 @@ public class FieldsContainKeywordsPredicate implements Predicate<Person>{
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream().anyMatch(keyword -> StringUtil.containsKeywordsListIgnoreCase(person.getAllFieldsAsString(), keyword));
+        return keywords.stream().anyMatch(keyword ->
+                StringUtil.containsKeywordsListIgnoreCase(person.getAllFieldsAsString(), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/connectus/model/person/Person.java
+++ b/src/main/java/seedu/connectus/model/person/Person.java
@@ -93,7 +93,8 @@ public class Person {
     }
 
     public String getAllFieldsAsString() {
-        return String.format("%s %s %s %s %s %s %s %s", name, phone, email, address, birthday, socialMedia, tags, modules);
+        return String.format("%s %s %s %s %s %s %s %s",
+                name, phone, email, address, birthday, socialMedia, tags, modules);
     }
 
     /**

--- a/src/main/java/seedu/connectus/model/person/Person.java
+++ b/src/main/java/seedu/connectus/model/person/Person.java
@@ -92,6 +92,10 @@ public class Person {
         return socialMedia;
     }
 
+    public String getAllFieldsAsString() {
+        return String.format("%s %s %s %s %s %s %s %s", name, phone, email, address, birthday, socialMedia, tags, modules);
+    }
+
     /**
      * Returns an immutable tag set, which throws
      * {@code UnsupportedOperationException}

--- a/src/test/java/seedu/connectus/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/connectus/commons/util/StringUtilTest.java
@@ -86,7 +86,8 @@ public class StringUtilTest {
 
     @Test
     public void containsKeywordsListIgnoreCase_nullWord_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsKeywordsListIgnoreCase("typical sentence", null));
+        assertThrows(NullPointerException.class, ()
+                -> StringUtil.containsKeywordsListIgnoreCase("typical sentence", null));
     }
 
     @Test
@@ -157,16 +158,17 @@ public class StringUtilTest {
         assertFalse(StringUtil.containsKeywordsListIgnoreCase("", "abc")); // Boundary case
         assertFalse(StringUtil.containsKeywordsListIgnoreCase("    ", "123"));
 
-        // Matches a partial word only
-        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
-        assertFalse(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
+        // Sentence word bigger than query word
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "bb"));
+        // Query word bigger than sentence word
+        assertFalse(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "bbbb"));
 
         // Matches word in the sentence, different upper/lower case letters
-        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bBb ccc", "Bbb")); // First word (boundary case)
-        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
-        assertTrue(StringUtil.containsKeywordsListIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
-        assertTrue(StringUtil.containsKeywordsListIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
-        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bBb ccc", "Bbb"));
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bBb ccc@1", "CCc@1"));
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("  AAA   bBb   ccc  ", "aaa"));
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("Aaa", "aaa"));
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "  ccc  "));
 
         // Matches multiple words in sentence
         assertTrue(StringUtil.containsKeywordsListIgnoreCase("AAA bBb ccc  bbb", "bbB"));

--- a/src/test/java/seedu/connectus/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/connectus/commons/util/StringUtilTest.java
@@ -76,6 +76,36 @@ public class StringUtilTest {
         assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase(null, "abc"));
     }
 
+    //---------------- Tests for containsKeywordsListIgnoreCase --------------------------------------
+
+    /*
+     * Invalid equivalence partitions for word: null, empty, multiple words
+     * Invalid equivalence partitions for sentence: null
+     * The four test cases below test one invalid input at a time.
+     */
+
+    @Test
+    public void containsKeywordsListIgnoreCase_nullWord_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsKeywordsListIgnoreCase("typical sentence", null));
+    }
+
+    @Test
+    public void containsKeywordsListIgnoreCase_emptyWord_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
+                -> StringUtil.containsKeywordsListIgnoreCase("typical sentence", "  "));
+    }
+
+    @Test
+    public void containsKeywordsListIgnoreCase_multipleWords_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Word parameter should be a single word", ()
+                -> StringUtil.containsKeywordsListIgnoreCase("typical sentence", "aaa BBB"));
+    }
+
+    @Test
+    public void containsKeywordsListIgnoreCase_nullSentence_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsKeywordsListIgnoreCase(null, "abc"));
+    }
+
     /*
      * Valid equivalence partitions for word:
      *   - any word
@@ -93,10 +123,7 @@ public class StringUtilTest {
      *   - last word in sentence
      *   - middle word in sentence
      *   - matches multiple words
-     *
-     * Possible scenarios returning false:
-     *   - query word matches part of a sentence word
-     *   - sentence word matches part of the query word
+     *   - partial word
      *
      * The test method below tries to verify all above with a reasonably low number of test cases.
      */
@@ -121,6 +148,28 @@ public class StringUtilTest {
 
         // Matches multiple words in sentence
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
+    }
+
+    @Test
+    public void containsKeywordsListIgnoreCase_validInputs_correctResult() {
+
+        // Empty sentence
+        assertFalse(StringUtil.containsKeywordsListIgnoreCase("", "abc")); // Boundary case
+        assertFalse(StringUtil.containsKeywordsListIgnoreCase("    ", "123"));
+
+        // Matches a partial word only
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
+        assertFalse(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
+
+        // Matches word in the sentence, different upper/lower case letters
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bBb ccc", "Bbb")); // First word (boundary case)
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
+
+        // Matches multiple words in sentence
+        assertTrue(StringUtil.containsKeywordsListIgnoreCase("AAA bBb ccc  bbb", "bbB"));
     }
 
     //---------------- Tests for getDetails --------------------------------------

--- a/src/test/java/seedu/connectus/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/connectus/logic/commands/SearchCommandTest.java
@@ -19,7 +19,6 @@ import seedu.connectus.model.Model;
 import seedu.connectus.model.ModelManager;
 import seedu.connectus.model.UserPrefs;
 import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
-import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code SearchCommand}.

--- a/src/test/java/seedu/connectus/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/connectus/logic/commands/SearchCommandTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.connectus.model.Model;
 import seedu.connectus.model.ModelManager;
 import seedu.connectus.model.UserPrefs;
+import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
 import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -29,10 +30,10 @@ public class SearchCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        FieldsContainKeywordsPredicate firstPredicate =
+                new FieldsContainKeywordsPredicate(Collections.singletonList("first"));
+        FieldsContainKeywordsPredicate secondPredicate =
+                new FieldsContainKeywordsPredicate(Collections.singletonList("second"));
 
         SearchCommand searchFirstCommand = new SearchCommand(firstPredicate);
         SearchCommand searchSecondCommand = new SearchCommand(secondPredicate);
@@ -57,7 +58,7 @@ public class SearchCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FieldsContainKeywordsPredicate predicate = preparePredicate(" ");
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +68,7 @@ public class SearchCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        FieldsContainKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -77,7 +78,7 @@ public class SearchCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private FieldsContainKeywordsPredicate preparePredicate(String userInput) {
+        return new FieldsContainKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/connectus/logic/parser/ConnectUsParserTest.java
+++ b/src/test/java/seedu/connectus/logic/parser/ConnectUsParserTest.java
@@ -24,7 +24,6 @@ import seedu.connectus.logic.commands.ListCommand;
 import seedu.connectus.logic.commands.SearchCommand;
 import seedu.connectus.logic.parser.exceptions.ParseException;
 import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
-import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 import seedu.connectus.model.person.Person;
 import seedu.connectus.testutil.EditPersonDescriptorBuilder;
 import seedu.connectus.testutil.PersonBuilder;

--- a/src/test/java/seedu/connectus/logic/parser/ConnectUsParserTest.java
+++ b/src/test/java/seedu/connectus/logic/parser/ConnectUsParserTest.java
@@ -23,6 +23,7 @@ import seedu.connectus.logic.commands.HelpCommand;
 import seedu.connectus.logic.commands.ListCommand;
 import seedu.connectus.logic.commands.SearchCommand;
 import seedu.connectus.logic.parser.exceptions.ParseException;
+import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
 import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 import seedu.connectus.model.person.Person;
 import seedu.connectus.testutil.EditPersonDescriptorBuilder;
@@ -73,7 +74,7 @@ public class ConnectUsParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         SearchCommand command = (SearchCommand) parser.parseCommand(
                 SearchCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new SearchCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new SearchCommand(new FieldsContainKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/connectus/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/connectus/logic/parser/SearchCommandParserTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.connectus.logic.commands.SearchCommand;
 import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
-import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 
 public class SearchCommandParserTest {
 

--- a/src/test/java/seedu/connectus/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/connectus/logic/parser/SearchCommandParserTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.connectus.logic.commands.SearchCommand;
+import seedu.connectus.model.person.FieldsContainKeywordsPredicate;
 import seedu.connectus.model.person.NameContainsKeywordsPredicate;
 
 public class SearchCommandParserTest {
@@ -24,7 +25,7 @@ public class SearchCommandParserTest {
     public void parse_validArgs_returnsSearchCommand() {
         // no leading and trailing whitespaces
         SearchCommand expectedSearchCommand =
-                new SearchCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new SearchCommand(new FieldsContainKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedSearchCommand);
 
         // multiple whitespaces between keywords


### PR DESCRIPTION
Currently, search command only searches for names that match the keyword. This PR implements a more general search function to search through all information fields for the specified keywords. 
#86 #89 