### PR TITLE
(WIP) Help - adding help functionality

### DIFF
--- a/src/main/java/seedu/connectus/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/connectus/logic/commands/ClearCommand.java
@@ -11,8 +11,12 @@ import seedu.connectus.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "ConnectUS has been cleared!";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears all entries from the ConnectUS app.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "ConnectUS has been cleared!";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/connectus/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/connectus/logic/commands/ExitCommand.java
@@ -9,6 +9,10 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Exits the program.\n"
+            + "Example: " + COMMAND_WORD;
+
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting ConnectUS as requested ...";
 
     @Override

--- a/src/main/java/seedu/connectus/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/connectus/logic/commands/HelpCommand.java
@@ -10,12 +10,34 @@ public class HelpCommand extends Command {
     public static final String COMMAND_WORD = "help";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+            + "Entering '" + COMMAND_WORD + "' alone returns a separate window with the link to the User Guide.\n"
+            + "Entering '" + COMMAND_WORD + " [COMMAND]' will return the usage instructions for the specified command.\n"
+            + "Example: '" + COMMAND_WORD + " add";
 
+    private final boolean isHelpWindowShown;
+    private final String helpMessage;
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+
+    public HelpCommand() {
+        this.isHelpWindowShown = true;
+        this.helpMessage = SHOWING_HELP_MESSAGE;
+    }
+
+    public HelpCommand(String command) {
+        this.isHelpWindowShown = false;
+        this.helpMessage = command;
+    }
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(helpMessage, isHelpWindowShown, false);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof HelpCommand // instanceof handles nulls
+                && isHelpWindowShown == ((HelpCommand) other).isHelpWindowShown
+                && helpMessage.equals(((HelpCommand) other).helpMessage));
     }
 }

--- a/src/main/java/seedu/connectus/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/connectus/logic/commands/ListCommand.java
@@ -12,6 +12,10 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows a list of all persons in the ConnectUS app.\n"
+            + "Example: " + COMMAND_WORD;
+
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
 


### PR DESCRIPTION
Currently, the help command only returns the URL to the User Guide, which is not very efficient for users as they will need to look through the whole User Guide to find the command they want to use. 

Proposal: add a `help [COMMAND]` feature on top of the current help command, such that:
- when `help` is called, it returns the URL to the User Guide
- when `help [COMMAND]` is called, it returns the usage instructions for the specified command e.g. `help add` returns usage instructions for `add`